### PR TITLE
Use same package as non-test files in string_test.go

### DIFF
--- a/string_test.go
+++ b/string_test.go
@@ -1,7 +1,6 @@
-package gojs_test
+package gojs
 
 import (
-	"gojs"
 	"testing"
 )
 
@@ -10,12 +9,12 @@ var (
 )
 
 func TestString(t *testing.T) {
-	str := gojs.NewString("a string")
+	str := NewString("a string")
 	defer str.Release()
 }
 
 func TestString2(t *testing.T) {
-	str := gojs.NewString("a string")
+	str := NewString("a string")
 	defer str.Release()
 
 	str.Retain()
@@ -24,7 +23,7 @@ func TestString2(t *testing.T) {
 
 func TestStringString(t *testing.T) {
 	for _, item := range strtests {
-		str := gojs.NewString(item)
+		str := NewString(item)
 		defer str.Release()
 
 		if str.String() != item {
@@ -37,11 +36,11 @@ func TestStringString(t *testing.T) {
 }
 
 func TestStringEqual(t *testing.T) {
-	lhs := gojs.NewString("dummy")
+	lhs := NewString("dummy")
 	defer lhs.Release()
 
 	for _, item := range strtests {
-		str := gojs.NewString(item)
+		str := NewString(item)
 		defer str.Release()
 
 		if lhs.Equal(str) {
@@ -54,7 +53,7 @@ func TestStringEqual(t *testing.T) {
 			t.Errorf("String did not compared as equal to itself \"%v\", and \"%v\"", str)
 		}
 
-		str2 := gojs.NewString(item)
+		str2 := NewString(item)
 		defer str2.Release()
 		if !str.Equal(str2) {
 			t.Errorf("String did not compared as equal to itself \"%v\", and \"%v\"", str2)
@@ -63,11 +62,11 @@ func TestStringEqual(t *testing.T) {
 }
 
 func TestStringEqualToString(t *testing.T) {
-	lhs := gojs.NewString("dummy")
+	lhs := NewString("dummy")
 	defer lhs.Release()
 
 	for _, item := range strtests {
-		str := gojs.NewString(item)
+		str := NewString(item)
 		defer str.Release()
 
 		if lhs.EqualToString(item) {


### PR DESCRIPTION
I apologize if there was a reason you put string_test.go in a test-only package. If so, please disregard. Otherwise, this PR changes string_test.go to use the gojs package so that `go test` works if you check out the repo using `go get` or check it out anywhere other than the root of the GOPATH.
