### PR TITLE
WrapContext func to allow use of externally obtained JSContextRef (e.g., from WebKit)

### DIFF
--- a/context.go
+++ b/context.go
@@ -14,9 +14,11 @@ func NewContext() *Context {
 	return ctx
 }
 
-func newContext(ref C.JSContextRef) *Context {
+type RawContext C.JSContextRef
+
+func NewContextFrom(raw RawContext) *Context {
 	ctx := new(Context)
-	ctx.ref = ref
+	ctx.ref = C.JSContextRef(raw)
 
 	return ctx
 }

--- a/native.go
+++ b/native.go
@@ -275,7 +275,7 @@ func (ctx *Context) NewFunctionWithCallback(callback GoFunctionCallback) *Object
 
 //export nativecallback_CallAsFunction_go
 func nativecallback_CallAsFunction_go(data_ptr unsafe.Pointer, uctx unsafe.Pointer, uobj unsafe.Pointer, uthisObject unsafe.Pointer, argumentCount uint, arguments unsafe.Pointer, exception *unsafe.Pointer) unsafe.Pointer {
-	ctx := newContext(C.JSContextRef(uctx))
+	ctx := NewContextFrom(RawContext(uctx))
 	defer func() {
 		if r := recover(); r != nil {
 			*exception = unsafe.Pointer(recover_to_javascript(ctx, r).ref)
@@ -342,7 +342,7 @@ func docall(ctx *Context, val reflect.Value, argumentCount uint, arguments unsaf
 
 //export nativefunction_CallAsFunction_go
 func nativefunction_CallAsFunction_go(data_ptr unsafe.Pointer, uctx unsafe.Pointer, _ unsafe.Pointer, _ unsafe.Pointer, argumentCount uint, arguments unsafe.Pointer, exception *unsafe.Pointer) unsafe.Pointer {
-	ctx := newContext(C.JSContextRef(uctx))
+	ctx := NewContextFrom(RawContext(uctx))
 	defer func() {
 		if r := recover(); r != nil {
 			*exception = unsafe.Pointer(recover_to_javascript(ctx, r).ref)
@@ -388,7 +388,7 @@ func (ctx *Context) NewNativeObject(obj interface{}) *Object {
 
 //export nativeobject_GetProperty_go
 func nativeobject_GetProperty_go(data_ptr, uctx, _, propertyName unsafe.Pointer, exception *unsafe.Pointer) unsafe.Pointer {
-	ctx := newContext(C.JSContextRef(uctx))
+	ctx := NewContextFrom(RawContext(uctx))
 	// Get name of property as a go string
 	name := (*String)(propertyName).String()
 
@@ -443,7 +443,7 @@ func internal_go_error(ctx *Context) *Exception {
 
 //export nativeobject_SetProperty_go
 func nativeobject_SetProperty_go(data_ptr, uctx, _, propertyName, value unsafe.Pointer, exception *unsafe.Pointer) C.char {
-	ctx := newContext(C.JSContextRef(uctx))
+	ctx := NewContextFrom(RawContext(uctx))
 	// Get name of property as a go string
 	name := (*String)(propertyName).String()
 
@@ -507,7 +507,7 @@ func newNativeMethod(ctx *Context, obj *object_data, method int) *Object {
 
 //export nativemethod_CallAsFunction_go
 func nativemethod_CallAsFunction_go(data_ptr unsafe.Pointer, uctx unsafe.Pointer, obj unsafe.Pointer, thisObject unsafe.Pointer, argumentCount uint, arguments unsafe.Pointer, exception *unsafe.Pointer) unsafe.Pointer {
-	ctx := newContext(C.JSContextRef(uctx))
+	ctx := NewContextFrom(RawContext(uctx))
 	defer func() {
 		if r := recover(); r != nil {
 			*exception = unsafe.Pointer(recover_to_javascript(ctx, r))


### PR DESCRIPTION
I am modifying https://github.com/mattn/go-webkit to expose the JSGlobalContextRef in a WebKit frame, and I would like to use gojs to evaluate scripts in the frame. To use gojs, it needs to be able to accept an externally obtained JSContextRef. This PR updates it to do so. There are probably a lot of ways to do this, and I know the API is undergoing changes, so feel free to reject this or suggest another way.

Specifically, what will become possible is this, which is essentially the core features of PhantomJS available in Go.

``` go
package webkit

import (
    "github.com/mattn/go-gtk/gtk"
    "github.com/sqs/gojs"
    "testing"
)

func TestEvaluateScript(t *testing.T) {
    gtk.Init(nil)
    webview := NewWebView()

    loaded := false
    webview.LoadHtmlString("<html><head><title>foo</title></head><body></body></html>", "http://example.com")
    webview.Connect("resource-load-finished", func() {
        defer gtk.MainQuit()
        loaded = true
        ctx := webview.GetMainFrame().GetGlobalContext()
        ctx2 := gojs.NewContextFrom(gojs.RawContext(ctx.ref))
        ret, err := ctx2.EvaluateScript(`"foo2"`, nil, ".", 0)
        if err != nil {
            t.Errorf("error: %s", err)
        }
        retstr := ctx2.ToStringOrDie(ret)
        wantRes := "foo"
        if wantRes != retstr {
            t.Errorf("want result %q, got %q", wantRes, retstr)
        }
    })
    gtk.Main()

    if !loaded {
        t.Errorf("!loaded")
    }
}
```

Thanks for the great lib!
