### PR TITLE
Expose NewValueFrom function to allow wrapping of externally obtained JSValueRefs

### DIFF
--- a/value.go
+++ b/value.go
@@ -109,6 +109,12 @@ func (ctx *Context) newValue(ref C.JSValueRef) *Value {
 	return val
 }
 
+type RawValue C.JSValueRef
+
+func (ctx *Context) NewValueFrom(raw RawValue) *Value {
+	return ctx.newValue(C.JSValueRef(raw))
+}
+
 func (ctx *Context) NewUndefinedValue() *Value {
 	return ctx.newValue(C.JSValueMakeUndefined(ctx.ref))
 }

--- a/value_test.go
+++ b/value_test.go
@@ -53,3 +53,17 @@ func jsObjectToJSValue(obj *Object, err error) *Value {
 	}
 	return obj.ToValue()
 }
+
+func TestNewValueFrom(t *testing.T) {
+	ctx := NewContext()
+	defer ctx.Release()
+
+	wantString := "foo"
+	jsval := ctx.NewStringValue(wantString)
+	rawval := RawValue(jsval.ref)
+	jsval2 := ctx.NewValueFrom(rawval)
+
+	if gotString := ctx.ToStringOrDie(jsval2); wantString != gotString {
+		t.Errorf("want string %q, got %q", wantString, gotString)
+	}
+}


### PR DESCRIPTION
Just like NewContextFrom, this enables gojs to be used with JSValueRefs obtained externally (e.g., from WebKit).
