### PR TITLE
Fix type error in Go 1.3

### DIFF
--- a/base.go
+++ b/base.go
@@ -9,14 +9,6 @@ import (
 	"unsafe"
 )
 
-// Context wraps a JavaScriptCore JSContextRef.
-type Context struct {
-	ref C.JSContextRef
-}
-
-// GlobalContext wraps a JavaScriptCore JSGlobalContextRef.
-type GlobalContext Context
-
 // EvaluateScript evaluates the JavaScript code in script.
 func (ctx *Context) EvaluateScript(script string, thisObject *Object, sourceURL string, startingLineNumber int) (*Value, error) {
 	scriptRef := NewString(script)

--- a/context.go
+++ b/context.go
@@ -5,6 +5,14 @@ package gojs
 import "C"
 import "unsafe"
 
+// Context wraps a JavaScriptCore JSContextRef.
+type Context struct {
+	ref C.JSContextRef
+}
+
+// GlobalContext wraps a JavaScriptCore JSGlobalContextRef.
+type GlobalContext Context
+
 func NewContext() *Context {
 	const c_nil = unsafe.Pointer(uintptr(0))
 
@@ -16,10 +24,17 @@ func NewContext() *Context {
 
 type RawContext C.JSContextRef
 
+type RawGlobalContext C.JSGlobalContextRef
+
 func NewContextFrom(raw RawContext) *Context {
 	ctx := new(Context)
 	ctx.ref = C.JSContextRef(raw)
+	return ctx
+}
 
+func NewGlobalContextFrom(raw RawGlobalContext) *GlobalContext {
+	ctx := new(GlobalContext)
+	ctx.ref = C.JSContextRef(raw)
 	return ctx
 }
 

--- a/context.go
+++ b/context.go
@@ -10,7 +10,7 @@ func NewContext() *Context {
 
 	ctx := new(Context)
 
-	ctx.ref = C.JSContextRef(C.JSGlobalContextCreate((*[0]uint8)(c_nil)))
+	ctx.ref = C.JSContextRef(C.JSGlobalContextCreate((C.JSClassRef)(c_nil)))
 	return ctx
 }
 


### PR DESCRIPTION
Suggested by the poster at https://github.com/sourcegraph/go-webkit2/issues/12#issuecomment-47535929/

Fixes a type error introduced by changes in Go 1.3.

```
$ go test ./...
# github.com/crazy2be/gojs
../../crazy2be/gojs/context.go:13: cannot use (*[0]uint8)(c_nil) (type *[0]uint8) as type *C.struct_OpaqueJSClass in argument to _Cfunc_JSGlobalContextCreate

```

As far as I can tell, this change is necessary for gojs to compile in Go 1.3.
